### PR TITLE
Updated Cybersyn source YML and SQL files

### DIFF
--- a/models/staging/marketplace_cybersyn/marketplace_cybersyn__sources.yml
+++ b/models/staging/marketplace_cybersyn/marketplace_cybersyn__sources.yml
@@ -5,4 +5,4 @@ sources:
     database: frostbyte_cs_public
     schema: cybersyn
     tables:
-      - name: public_holiday_calendar
+      - name: public_holidays

--- a/models/staging/marketplace_cybersyn/stg_cybersyn__holidays.sql
+++ b/models/staging/marketplace_cybersyn/stg_cybersyn__holidays.sql
@@ -2,7 +2,7 @@
 with
     source as (
         select *
-          from {{ source("marketplace_cybersyn", "public_holiday_calendar") }}
+          from {{ source("marketplace_cybersyn", "public_holidays") }}
     ),
 
     renamed as (


### PR DESCRIPTION
I had a few dbt builds fail due to a view not found error.  Debugged and found that Cybersyn changed their naming convention on a view in the Cybersync schema from "public_holiday_calendar" to "public_holidays".  After adjusting with the edits in my commits, dbt build ran successfully.